### PR TITLE
Make underscorifying keys optional; make HTTPotion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ This parser is [available in Hex](https://hex.pm/packages/microformats2):
            [{:microformats2, "~> 0.2.0"}]
          end
 
+  2. If you want to directly `parse` from URLs, add httpotion to your list of dependencies in `mix.exs`:
+
+         def deps do
+           [{:microformats2, "~> 0.2.0"},
+            {:httpotion, "~> 3.1"}]
+         end
 
 
 ## Usage
 
-Give the parser an HTML string:
+Give the parser an HTML string and the URL it was fetched from:
 
     Microformats2.parse("""<div class="h-card">
       <img class="u-photo" alt="photo of Mitchell"
@@ -31,7 +37,7 @@ Give the parser an HTML string:
       <span class="p-category">Strategy</span>
       <span class="p-category">Leadership</span>
     </div>
-    """)
+    """, "http://localhost")
 
 It will parse the object to a structure like that:
 
@@ -49,7 +55,11 @@ It will parse the object to a structure like that:
 
 You can also provide HTML trees already parsed with Floki:
 
-    Microformats2.parse(Floki.parse("""<div class="h-card">...</div>"""))
+    Microformats2.parse(Floki.parse("""<div class="h-card">...</div>"""), "http://localhost")
+
+Or URLs if you have HTTPotion installed:
+
+    Microformats2.parse("http://localhost")
 
 ## Dependencies
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -81,7 +81,9 @@ defmodule Microformats2.Helpers do
 
   @spec to_key(String.t()) :: String.t()
   def to_key(str) do
-    String.replace(str, ~r/[-]/, "_")
+    if Application.get_env(:microformats2, :underscore_keys, true),
+      do: String.replace(str, ~r/[-]/, "_"),
+      else: str
   end
 
   @spec normalized_key(String.t()) :: String.t() | atom()

--- a/lib/microformats2.ex
+++ b/lib/microformats2.ex
@@ -1,11 +1,13 @@
 defmodule Microformats2 do
-  def parse(url) do
-    response = HTTPotion.get(url, follow_redirects: true)
+  if Code.ensure_loaded?(HTTPotion) do
+    def parse(url) do
+      response = HTTPotion.get(url, follow_redirects: true)
 
-    if HTTPotion.Response.success?(response) do
-      parse(response.body, url)
-    else
-      :error
+      if HTTPotion.Response.success?(response) do
+        parse(response.body, url)
+      else
+        :error
+      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Microformats2.Mixfile do
   defp deps do
     [
       {:floki, "~> 0.7"},
-      {:httpotion, "~> 3.0"},
+      {:httpotion, "~> 3.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "floki": {:hex, :floki, "0.20.4", "be42ac911fece24b4c72f3b5846774b6e61b83fe685c2fc9d62093277fb3bc86", [:mix], [{:html_entities, "~> 0.4.0", [hex: :html_entities, repo: "hexpm", optional: false]}, {:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
   "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
-  "httpotion": {:hex, :httpotion, "3.1.1", "b8ad199dea2c56a70c89e7f9e4d09898c7e85871783b7417c04cb4f1d4d8e919", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpotion": {:hex, :httpotion, "3.1.3", "fdaf1e16b9318dcb722de57e75ac368c93d4c6e3c9125f93e960f953a750fb77", [:mix], [{:ibrowse, "== 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
That caught me off guard, webmentions were not recognized because I was looking for `in-reply-to` not `in_reply_to`.