### PR TITLE
Make use of normalized key to atomize keys.

### DIFF
--- a/lib/implied.ex
+++ b/lib/implied.ex
@@ -24,7 +24,7 @@ defmodule Microformats2.Items.ImpliedProperties do
 
       if blank?(url),
         do: entry,
-        else: put_in(entry, [:properties, "url"], [abs_uri(url, doc_url, doc)])
+        else: put_in(entry, [normalized_key("properties"), "url"], [abs_uri(url, doc_url, doc)])
     else
       entry
     end
@@ -44,7 +44,7 @@ defmodule Microformats2.Items.ImpliedProperties do
 
       if blank?(url),
         do: entry,
-        else: put_in(entry, [:properties, "photo"], [url])
+        else: put_in(entry, [normalized_key("properties"), "photo"], [url])
     else
       entry
     end

--- a/lib/implied.ex
+++ b/lib/implied.ex
@@ -11,7 +11,7 @@ defmodule Microformats2.Items.ImpliedProperties do
   end
 
   defp implied_url_property(entry, root, doc_url, doc) do
-    if entry[:properties]["url"] == nil do
+    if entry[normalized_key("properties")]["url"] == nil do
       val = implied_url_attrval(root)
 
       url =
@@ -31,7 +31,7 @@ defmodule Microformats2.Items.ImpliedProperties do
   end
 
   defp implied_photo_property(entry, root) do
-    if entry[:properties]["photo"] == nil do
+    if entry[normalized_key("properties")]["photo"] == nil do
       val = implied_photo_attrval(root)
 
       url =
@@ -51,7 +51,7 @@ defmodule Microformats2.Items.ImpliedProperties do
   end
 
   defp implied_name_property(entry, root = {elem, _, _}) do
-    if entry[:properties]["name"] == nil do
+    if entry[normalized_key("properties")][normalized_key("name")] == nil do
       nam =
         cond do
           elem == "img" or elem == "area" ->
@@ -69,7 +69,7 @@ defmodule Microformats2.Items.ImpliedProperties do
         end
         |> stripped_or_nil()
 
-      put_in(entry, [:properties, "name"], [nam])
+      put_in(entry, [normalized_key("properties"), "name"], [nam])
     else
       entry
     end

--- a/lib/microformats2.ex
+++ b/lib/microformats2.ex
@@ -10,6 +10,7 @@ defmodule Microformats2 do
       end
     end
   end
+  import Microformats2.Helpers, only: [normalized_key: 1]
 
   def parse(content, url) when is_binary(content) do
     case Floki.parse_document(content) do
@@ -29,6 +30,9 @@ defmodule Microformats2 do
     rels = Microformats2.Rels.parse(doc, url)
     items = Microformats2.Items.parse(doc, doc, url)
 
-    %{items: items, rels: rels[:rels], rel_urls: rels[:rel_urls]}
+    Map.new
+    |> Map.put(normalized_key("items"), items)
+    |> Map.put(normalized_key("rels"), rels[normalized_key("rels")])
+    |> Map.put(normalized_key("rel_urls"), rels[normalized_key("rel_urls")])
   end
 end

--- a/lib/rels.ex
+++ b/lib/rels.ex
@@ -2,6 +2,7 @@ defmodule Microformats2.Rels do
   import Microformats2.Helpers
 
   def parse(doc, base_url) do
+    base_resp = Map.new |> Map.put(normalized_key("rels"), %{}) |> Map.put(normalized_key("rel_urls"), %{})
     link_rels =
       Floki.find(doc, "[rel][href]")
       |> Enum.filter(fn element ->
@@ -10,7 +11,7 @@ defmodule Microformats2.Rels do
 
         String.trim(to_string(rel)) != "" and String.trim(to_string(href)) != ""
       end)
-      |> Enum.reduce(%{rels: %{}, rel_urls: %{}}, fn element, acc ->
+      |> Enum.reduce(base_resp, fn element, acc ->
         rel = attr_list(element, "rel")
         url = Floki.attribute(element, "href") |> List.first() |> abs_uri(base_url, doc)
 
@@ -25,34 +26,36 @@ defmodule Microformats2.Rels do
 
   defp save_urls_by_rels(map, rel, url) do
     Enum.reduce(rel, map, fn rel, nmap ->
-      if nmap[:rels][rel] == nil,
-        do: put_in(nmap, [:rels, rel], [url]),
-        else: put_in(nmap, [:rels, rel], Enum.uniq(nmap[:rels][rel] ++ [url]))
+      if nmap[normalized_key("rels")][rel] == nil,
+        do: put_in(nmap, [normalized_key("rels"), rel], [url]),
+        else: put_in(nmap, [normalized_key("rels"), rel], Enum.uniq(nmap[normalized_key("rels")][rel] ++ [url]))
     end)
   end
 
   defp save_rels_by_urls(map, rel, url) do
-    if map[:rel_urls][url] == nil,
-      do: put_in(map, [:rel_urls, url], %{rels: rel}),
-      else: put_in(map, [:rel_urls, url, :rels], Enum.uniq(map[:rel_urls][url][:rels] ++ rel))
+    if map[normalized_key("rel_urls")][url] == nil do
+      put_in(map, [normalized_key("rel_urls"), url], Map.new([{normalized_key("rels"), rel}]))
+    else
+      put_in(map, [normalized_key("rel_urls"), url, normalized_key("rels")], Enum.uniq(map[normalized_key("rel_urls")][url][normalized_key("rels")] ++ rel))
+    end
   end
 
   defp save_text(map, element, url) do
     text = Floki.text(element)
 
-    if String.trim(to_string(text)) == "" or map[:rel_urls][url][:text] != nil,
+    if String.trim(to_string(text)) == "" or map[normalized_key("rel_urls")][url][normalized_key("text")] != nil,
       do: map,
-      else: put_in(map, [:rel_urls, url, :text], text)
+      else: put_in(map, [normalized_key("rel_urls"), url, normalized_key("text")], text)
   end
 
   defp save_attributes(map, element, url) do
     Enum.reduce(["hreflang", "media", "title", "type"], save_text(map, element, url), fn att, nmap ->
       val = Floki.attribute(element, att) |> List.first()
-      key = String.to_atom(att)
+      key = normalized_key(att)
 
-      if String.trim(to_string(val)) == "" or nmap[:rel_urls][url][key] != nil,
+      if String.trim(to_string(val)) == "" or nmap[normalized_key("rel_urls")][url][key] != nil,
         do: nmap,
-        else: put_in(nmap, [:rel_urls, url, key], val)
+        else: put_in(nmap, [normalized_key("rel_urls"), url, key], val)
     end)
   end
 end

--- a/test/items_test.exs
+++ b/test/items_test.exs
@@ -643,6 +643,66 @@ defmodule Microformats2ItemsTest do
            } = Microformats2.parse(str, "http://localhost")
   end
 
+  test "normalizes keys into strings" do
+    Application.put_env(:microformats2, :atomize_keys, false)
+
+   {:ok, str} = File.read("./test/documents/real_world_note.html")
+
+    assert %{
+             "rels" => _,
+             "rel_urls" => _,
+             "items" =>[
+               %{
+                 "properties" => %{
+                   "author" => [
+                     %{
+                       "properties" => %{
+                         "name" => ["Jeena"],
+                         "photo" => ["http://localhost/avatar.jpg"],
+                         "url" => ["http://localhost/"]
+                       },
+                       "type" => ["h-card"],
+                       "value" => "Jeena"
+                     }
+                   ],
+                   "comment" => [
+                     %{
+                       "properties" => %{
+                         "author" => [
+                           %{
+                             "properties" => %{
+                               "name" => ["Christian Kruse"],
+                               "photo" => [
+                                 "http://localhost/cache?size=40x40>&url=https%3A%2F%2Fwwwtech.de%2Fimages%2Fchristian-kruse-242470c34a3671da4cab3e3b0d941729.jpg%3Fvsn%3Dd"
+                               ],
+                               "url" => ["https://wwwtech.de/notes/132"]
+                             },
+                             "type" => ["h-card"],
+                             "value" =>"Christian Kruse"
+                           }
+                         ],
+                         "content" => [%{"html" => "Of course he is!", "text" => "Of course he is!"}],
+                         "name" => ["Christian Kruse,\n\t\t        4 days ago\n\t\t        Of course he is!"],
+                         "published" => ["2016-02-19T10:50:17Z"],
+                         "url" => ["https://wwwtech.de/notes/132"]
+                       },
+                       "type" => ["h-cite"],
+                       "value" => "Christian Kruse,\n\t\t        4 days ago\n\t\t        Of course he is!"
+                     }
+                   ],
+                   "content" => [%{"html" => "<p>He&apos;s right, you know?</p>", "text" => "He's right, you know?"}],
+                   "in-reply-to" => ["https://wwwtech.de/pictures/51"],
+                   "name" => ["Note #587"],
+                   "published" => ["2016-02-18T19:33:25Z"],
+                   "updated" => ["2016-02-18T19:33:25Z"],
+                   "url" => ["http://localhost/comments/587"]
+                 },
+                 "type" => ["h-as-note", "h-entry"]
+               }
+             ]
+           } = Microformats2.parse(str, "http://localhost")
+  end
+
   test "invalid attrs" do
     str = File.read!("./test/documents/invalid-attrs.html")
 


### PR DESCRIPTION
That makes use of the `normalize_key` method to conditionally atomize keys. I know there's a potential performance issue with using strings over atoms. However, when I do my templating via Liquid, it helps to have things as strings.