### PR TITLE
Fix warnings in elixir 1.11 about boundary checks

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Microformats2.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   def description do


### PR DESCRIPTION
Elixir 1.11 introduced some boundary checking for remote calls and
warns if there are calls to modules that are not properly defined as
dependencies.

This check did not work correctly due to the use of `:applications`
key in `application/0`.

This also fixes potential issues with releases not beeing packed up
properly.
