### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
+# Used by "mix format"
 [
-  inputs: ["lib/**/*.{ex,exs}", "mix.exs", "config/*.exs", "test/**/*.{ex,exs}"],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 120,
   rename_deprecated_at: "1.4.5"
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,26 @@
-/_build
-/cover
-/deps
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-/.elixir_ls
-/doc
+
+# Ignore package tarball (built via "mix hex.build").
+microformats2-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-Copyright 2018 Christian Kruse <cjk@defunct.ch>
+# The MIT License
+
+Copyright (c) 2018 Christian Kruse <cjk@defunct.ch>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 # Microformats2
 
+[![Module Version](https://img.shields.io/hexpm/v/microformats2.svg)](https://hex.pm/packages/microformats2)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/microformats2/)
+[![Total Download](https://img.shields.io/hexpm/dt/microformats2.svg)](https://hex.pm/packages/microformats2)
+[![License](https://img.shields.io/hexpm/l/microformats2.svg)](https://github.com/ckruse/microformats2-elixir/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/ckruse/microformats2-elixir.svg)](https://github.com/ckruse/microformats2-elixir/commits/master)
+
 A [Microformats2](http://microformats.org/wiki/microformats2) parser for Elixir.
 
 ## Installation
 
-This parser is [available in Hex](https://hex.pm/packages/microformats2):
+The package can be installed by adding `:microformat2` to your list of
+dependencies in `mix.exs`:
 
-1. Add microformats2 to your list of dependencies in `mix.exs`:
+```elixir
+def deps do
+  [
+    {:microformats2, "~> 0.7.4"}
+  ]
+end
+```
 
-   ```elixir
-   def deps do
-     [{:microformats2, "~> 0.7.4"}]
-   end
-   ```
+If you want to directly `parse` from URLs, add `:tesla` to your list of
+dependencies in `mix.exs`:
 
-2. If you want to directly `parse` from URLs, add `tesla` to your list of dependencies in `mix.exs`:
-
-   ```elixir
-   def deps do
-     [{:microformats2, "~> 0.7.4"},
-      {:tesla, "~> 1.4.3"}]
-   end
-   ```
+```elixir
+def deps do
+  [
+    {:microformats2, "~> 0.7.4"},
+    {:tesla, "~> 1.4.3"}
+  ]
+end
+```
 
 ## Usage
 
@@ -114,6 +124,9 @@ Not implemented:
 - [include-pattern](http://microformats.org/wiki/include-pattern)
 - backwards compatible support for microformats v1
 
-## License
+## Copyright and License
 
-This software is licensed under the [MIT license](https://choosealicense.com/licenses/mit/).
+Copyright (c) 2018 Christian Kruse <cjk@defunct.ch>
+
+This work is free. You can redistribute it and/or modify it under the
+terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/lib/microformats2.ex
+++ b/lib/microformats2.ex
@@ -1,6 +1,6 @@
 defmodule Microformats2 do
   @moduledoc """
-  A [microformats2](http://microformats.org/wiki/microformats2) parser for elixir.
+  A [microformats2](http://microformats.org/wiki/microformats2) parser for Elixir.
   """
 
   alias Microformats2.Helpers
@@ -68,6 +68,7 @@ defmodule Microformats2 do
         "rel-urls" => %{},
         "rels" => %{}
       }
+
   """
   @spec parse(String.t() | Floki.html_tree(), String.t() | keyword(), keyword()) :: :error | map()
   def parse(content_or_url, base_url_or_opts \\ [], opts \\ [])
@@ -116,7 +117,7 @@ defmodule Microformats2 do
   end
 
   # this is a really ugly hack, but html5ever doesn't support template tags (it fails with a nif_panic),
-  # mochiweb has bugs whith whitespaces and I can't really get fast_html to work
+  # mochiweb has bugs with whitespaces and I can't really get fast_html to work
   defp parsed_document(content) do
     content
     |> replace_whitespaces()

--- a/mix.exs
+++ b/mix.exs
@@ -1,17 +1,21 @@
 defmodule Microformats2.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/ckruse/microformats2-elixir"
+  @version "0.7.4"
+
   def project do
     [
       app: :microformats2,
-      version: "0.7.4",
+      version: @version,
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       description: description(),
       package: package(),
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ]
   end
 
@@ -36,25 +40,29 @@ defmodule Microformats2.Mixfile do
       files: ["lib", "mix.exs", "README.md", "LICENSE"],
       maintainers: ["Christian Kruse"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/ckruse/microformats2-elixir"}
+      links: %{"GitHub" => @source_url}
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [
       {:floki, "~> 0.7"},
       {:tesla, "~> 1.4.0", optional: true},
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:jason, "~> 1.2", only: [:dev, :test]}
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: @version,
+      formatters: ["html"]
     ]
   end
 end

--- a/test/documents/blocking-domains.html
+++ b/test/documents/blocking-domains.html
@@ -287,7 +287,7 @@
         <p>Hi, I'm <span class="p-name">Aaron<span style="display:none;"> Parecki</span></span>,  co-founder of
 <a class="p-org h-card" href="https://indieweb.org/">IndieWebCamp</a>.
 I maintain <a class="p-org h-card" href="https://oauth.net/">oauth.net</a>, <a href="/oauth/">write and consult about OAuth</a>, and
-am the editor of several <a href="/w3c/">W3C specfications</a>. I record <a href="https://backpedal.tv">videos for local conferences</a> and help run a <a href="https://streampdx.com">podcast studio in Portland</a>.</p>
+am the editor of several <a href="/w3c/">W3C specifications</a>. I record <a href="https://backpedal.tv">videos for local conferences</a> and help run a <a href="https://streampdx.com">podcast studio in Portland</a>.</p>
 
 <p>I wrote <a href="https://100.aaronparecki.com/">100 songs in 100 days</a>! I've been <a href="/gps/">tracking my location</a> since 2008,
 and write down everything I <a href="/ate">eat</a> and <a href="/drank">drink</a>.

--- a/test/items_test.exs
+++ b/test/items_test.exs
@@ -480,7 +480,7 @@ defmodule Microformats2.ItemsTest do
                    "callsign" => ["W7APK"],
                    "name" => ["Aaron Parecki"],
                    "note" => [
-                     "Hi, I'm Aaron Parecki,  co-founder of\nIndieWebCamp.\nI maintain oauth.net, write and consult about OAuth, and\nam the editor of several W3C specfications. I record videos for local conferences and help run a podcast studio in Portland.\n\nI wrote 100 songs in 100 days! I've been tracking my location since 2008,\nand write down everything I eat and drink.\nI've spoken at conferences around the world about\nowning your data,\nOAuth,\nquantified self,\nand explained why R is a vowel. Read more."
+                     "Hi, I'm Aaron Parecki,  co-founder of\nIndieWebCamp.\nI maintain oauth.net, write and consult about OAuth, and\nam the editor of several W3C specifications. I record videos for local conferences and help run a podcast studio in Portland.\n\nI wrote 100 songs in 100 days! I've been tracking my location since 2008,\nand write down everything I eat and drink.\nI've spoken at conferences around the world about\nowning your data,\nOAuth,\nquantified self,\nand explained why R is a vowel. Read more."
                    ],
                    "org" => [
                      %{


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.